### PR TITLE
Feat/grouped by part

### DIFF
--- a/app/controllers/api/v1/menus_controller.rb
+++ b/app/controllers/api/v1/menus_controller.rb
@@ -47,15 +47,15 @@ module Api
         end
       end
 
-      def grouped_by_machine
-        grouped = Menu.all.group_by (&:part)
+      def grouped_by_part
+        grouped = Menu.all.group_by(&:part)
         result = grouped.map do |part, menus|
           {
             name: part,
             exercises: menus.map(&:name).uniq
           }
         end
-        render json: response
+        render json: result
       end
 
       private

--- a/app/controllers/api/v1/menus_controller.rb
+++ b/app/controllers/api/v1/menus_controller.rb
@@ -47,6 +47,17 @@ module Api
         end
       end
 
+      def grouped_by_machine
+        grouped = Menu.all.group_by (&:part)
+        result = grouped.map do |part, menus|
+          {
+            name: part,
+            exercises: menus.map(&:name).uniq
+          }
+        end
+        render json: response
+      end
+
       private
 
       def menu_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,9 @@ Rails.application.routes.draw do
       resources :gyms, only: [ :create, :index ]
       resources :gym_machines, only: [ :create, :index ]
       resources :menus, only: [ :create, :index, :show, :update, :destroy ]
+       collection do
+        get :grouped_by_part
+      end
       resources :users_trainings, only: [ :create, :index ]
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
       resources :machines, only: [ :index, :create, :new ]
       resources :gyms, only: [ :create, :index ]
       resources :gym_machines, only: [ :create, :index ]
-      resources :menus, only: [ :create, :index, :show, :update, :destroy ]
+      resources :menus, only: [ :create, :index, :show, :update, :destroy ] do
        collection do
         get :grouped_by_part
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
        collection do
         get :grouped_by_part
       end
+      end
       resources :users_trainings, only: [ :create, :index ]
     end
   end


### PR DESCRIPTION
##  Pull Request: メニューを部位ごとに分類して取得できるAPIの追加

###  概要
部位（part）ごとにメニューをグループ化して返すエンドポイント `/api/v1/menus/grouped_by_part` を新たに追加しました。これにより、フロントエンドで部位別の種目リスト（例：Chest, Back, Legsなど）を構築しやすくなります。

---

###  主な変更点

- `MenusController` に `grouped_by_part` アクションを追加
  - `Menu.all.group_by(&:part)` により部位で分類し、
  - `{ name: part, exercises: [メニュー名, ...] }` 形式のJSONを返す
- ルーティング `routes.rb` に `get :grouped_by_part` を `menus` リソースにネストして追加
- Ruby構文エラー、無限再帰エラー、変数名ミス（`response`→`result`）を修正

---

###  エンドポイント仕様

#### `GET /api/v1/menus/grouped_by_part`

**レスポンス例：**

```json
[
  {
    "name": "胸（大胸筋）",
    "exercises": ["ダンベルプレス", "チェストプレス", ...]
  },
  {
    "name": "脚（大腿四頭筋）",
    "exercises": ["スクワット", "レッグプレス", ...]
  },
  ...
]